### PR TITLE
Solution and tests cs 1 cs 112 cs 113

### DIFF
--- a/solutions-sprint1-write-cpp-classes/alloc_log.h
+++ b/solutions-sprint1-write-cpp-classes/alloc_log.h
@@ -1,6 +1,9 @@
 #ifndef _alloc_log
 #define _alloc_log
 
+#include <iostream>
+#include <cstdlib>
+
 void* operator new(std::size_t sz)
 {
     static std::size_t alloc_cnt = 0;

--- a/solutions-sprint1-write-cpp-classes/my_string.inl
+++ b/solutions-sprint1-write-cpp-classes/my_string.inl
@@ -518,12 +518,10 @@ my_string<CharT>&
 my_string<CharT>::
 erase(std::size_t index, std::size_t count)
 {
-    if (count == npos) this->clear();
-    else if (count)
-        this->_mutate(_check_i_is_in_size(index, *this,
-                                          "index > size()"),
-                      std::min(count, this->size() - index),
-                      nullptr, std::size_t{ 0 });
+    this->_mutate(_check_i_is_in_size(index, *this,
+                                      "index > size()"),
+                  std::min(count, this->size() - index),
+                  nullptr, std::size_t{ 0 });
     
     return *this;
 }


### PR DESCRIPTION
1. `alloc_log.h`에 `include`문 추가
2. `my_string.inl`의 `erase`에서 `if` 분기 제거   
(`erase`가 `_mutate`에 넘기는 `argument`들에 따라 `clear`와 같은 동작을 할 수 있음.   
따라서 `_mutate`로 대체)